### PR TITLE
memory leak on dispose

### DIFF
--- a/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
+++ b/sdl_android/src/main/java/com/smartdevicelink/proxy/SdlProxyBase.java
@@ -3329,7 +3329,7 @@ public abstract class SdlProxyBase<proxyListenerType extends IProxyListenerBase>
 				updateBroadcastIntent(sendIntent, "DATA",serializeJSON(msg));
 				sendBroadcastIntent(sendIntent);
 
-				if (_advancedLifecycleManagementEnabled) {
+				if (!_proxyDisposed && _advancedLifecycleManagementEnabled) {
 					// This requires the proxy to be cycled
                     cycleProxy(SdlDisconnectedReason.convertAppInterfaceUnregisteredReason(msg.getReason()));
                 } else {


### PR DESCRIPTION
There is a memory leak when dispose proxy,because proxy will send UnRegisterApp and handle UnRegisterApp message from SDL_Core, in UnRegisterApp handler,proxy will be cycled according to the SdlProxyBase._advancedLifecycleManagementEnabled, but this param always true in SdlProxyALM.
Before dispose,the reference tree like this:
![image](https://user-images.githubusercontent.com/17377681/34137040-ad1e1f4e-e4a3-11e7-9415-36df6688070a.png)
After dispose,the reference tree like this:
![image](https://user-images.githubusercontent.com/17377681/34137072-dfad188e-e4a3-11e7-9956-21ecb400cbc7.png)
